### PR TITLE
added $SELECTION variable and added html clipboard content detection

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -57,9 +57,22 @@ browser.action.onClicked.addListener(handleAction);
 function copyToClipboard(templateString) {
   const formattedText = templateString
     .replace(/\$TITLE/g, document.title)
-    .replace(/\$URL/g, document.location.href);
+    .replace(/\$URL/g, document.location.href)
+    .replace(/\$SELECTION/g, document.getSelection().toString());
 
-  return navigator.clipboard.writeText(formattedText)
+  // Simple HTML detection - check if it contains HTML tags
+  const hasHtmlTags = /<[^>]+>/.test(formattedText);
+  
+  const clipboardItem = hasHtmlTags ? 
+    new ClipboardItem({
+      "text/html": new Blob([formattedText], { type: "text/html" }),
+      "text/plain": new Blob([formattedText.replace(/<[^>]*>/g, '')], { type: "text/plain" })
+    }) :
+    new ClipboardItem({
+      "text/plain": new Blob([formattedText], { type: "text/plain" })
+    });
+
+  return navigator.clipboard.write([clipboardItem])
     .then(() => true)
     .catch(err => {
       console.error('[Clipper] Failed copying to clipboard:', err);

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,5 +1,6 @@
 export const ORIGINAL_TEMPLATES = {
   "Plain": "Title: $TITLE\nURL: $URL\n",
   "Org Mode": "*** $TITLE\n:PROPERTIES:\n:url: $URL\n:END:\n\n",
-  "Markdown": "### [$TITLE]($URL)\n\n"
+  "Markdown": "### [$TITLE]($URL)\n\n",
+  "HTML": "<a href=\"$URL\">$TITLE</a>"
 };

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -62,6 +62,7 @@
                 <ul>
                   <li><code>$TITLE</code> - Current page title</li>
                   <li><code>$URL</code> - Current page address</li>
+                  <li><code>$SELECTION</code> - Current highlighted text</li>
                 </ul>
               </span>
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-help-icon lucide-circle-help"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -62,7 +62,7 @@
                 <ul>
                   <li><code>$TITLE</code> - Current page title</li>
                   <li><code>$URL</code> - Current page address</li>
-                  <li><code>$SELECTION</code> - Current highlighted text</li>
+                  <li><code>$SELECTION</code> - Currently selected text</li>
                 </ul>
               </span>
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-help-icon lucide-circle-help"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>


### PR DESCRIPTION
#1 - Add $SELECTION variable which grabs whatever the user has highlighted

#2 - Add html detection and parsing. If the content contains < or > characters, it is considered to be html and the html content is copied to clipboard. If < or > are not found, then it is considered to be plain text and previous behavior is maintained.

Also added a default template for HTML and updated helper icon to list the new variable